### PR TITLE
fixed grafana dashboards issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ oc create -f deploy/operator.yaml
 oc create -f deploy/crds/appmonitoring_v1_appmonitor-base-install_cr.yaml
 ```
 
-To use preprovisioned Grafana Dashboards create a configmap with the name grafana-dashboards in the project where the custom resource will be used and set ```grafana_dashboard_configmap: true``` in the AppMonitor CR. 
+To use preprovisioned Grafana Dashboards create a ConfigMap with the name `grafana-dashboards` in the project where the custom resource will be used and set `grafana_dashboard_configmap: true` in the AppMonitor CR.
+
+If you want to use a ConfigMap named other than `grafana-dashboards`, set `grafana_dashboard_configmap_name` to the name of the ConfigMap.
 
 ## Usage
-The operator deploys and configures Prometheus and Grafana into a project. Both deployments use oauth-proxy for authentication. Prometheus will be deployed with the help of prometheus-operator.
 
+The operator deploys and configures Prometheus and Grafana into a project. Both deployments use oauth-proxy for authentication. Prometheus will be deployed with the help of prometheus-operator.

--- a/roles/appmonitor/defaults/main.yml
+++ b/roles/appmonitor/defaults/main.yml
@@ -19,13 +19,15 @@ grafana_memory_limit: 200Mi
 grafana_cpu_request: 100m
 grafana_cpu_limit: 200m
 
-routes_use_encryption: true
+routes_tls: true
+routes_tls_termination: edge
 prometheus_api_group: app-monitoring.io
 registry: registry.redhat.io
 openshift_version: v3.11
 
 grafana_storage_type: none
 grafana_dashboard_configmap: false
+grafana_dashboard_configmap_name: grafana-dashboards
 cluster_default_image_pull_policy: Always
 
 replicas: 1

--- a/roles/appmonitor/tasks/app-monitoring.yml
+++ b/roles/appmonitor/tasks/app-monitoring.yml
@@ -226,9 +226,8 @@
     api_version: v1
     kind: ConfigMap
     namespace: "{{ meta.namespace }}"
-    name: "{{ grafana_dashboard_configmap }}"
-  register: grafana_cm
-  when: grafana_dashboard_configmap is defined and grafana_dashboard_configmap is not none
+    name: "{{ grafana_dashboard_configmap_name }}"
+  when: grafana_dashboard_configmap is defined and grafana_dashboard_configmap is not none and grafana_dashboard_configmap
 
 - name: "Grafana Deployment: template deployment and grafana-config"
   template:

--- a/roles/appmonitor/templates/grafana.yml.j2
+++ b/roles/appmonitor/templates/grafana.yml.j2
@@ -96,7 +96,7 @@ spec:
           name: grafana-proxy-secrets
         - mountPath: /etc/grafana/provisioning/datasources
           name: grafana-datasources
-{% if grafana_dashboard_configmap is defined and grafana_dashboard_configmap is not none %}
+{% if grafana_dashboard_configmap is defined and grafana_dashboard_configmap is not none and grafana_dashboard_configmap %}
         - mountPath: /etc/grafana/provisioning/dashboards
           name: grafana-dashboards
 {% endif %}
@@ -121,7 +121,7 @@ spec:
 {% else %}
         emptydir: {}
 {% endif %}
-{% if grafana_dashboard_configmap is defined and grafana_dashboard_configmap is not none %}
+{% if grafana_dashboard_configmap is defined and grafana_dashboard_configmap is not none and grafana_dashboard_configmap %}
       - configMap:
           defaultMode: 420
           name: grafana-dashboards

--- a/roles/appmonitor/templates/route.j2
+++ b/roles/appmonitor/templates/route.j2
@@ -12,7 +12,7 @@ spec:
   to:
     kind: Service
     name: {{ item }}
-{% if routes_use_encryption %}
+{% if routes_tls %}
   tls:
-    termination: edge
+    termination: {{ routes_tls_termination }}
 {% endif %}


### PR DESCRIPTION
This fixes the "grafana use configmap" conditionals to evaluate the
variable correctly.

added routes_tls* variables

This allows for more control over the route object generated in regards
to tls.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>